### PR TITLE
feat: redesign packing experience for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <title>Smart Packing Assistant | AI-Powered Travel Checklists</title>
     <meta name="description" content="Generate intelligent, destination-specific packing lists with AI. Get weather-aware, culturally-informed recommendations tailored to your travel style." />
     <meta name="author" content="Smart Packing Assistant" />
+    <meta name="theme-color" content="#1d4ed8" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/favicon.ico" />
 
     <meta property="og:title" content="Smart Packing Assistant | AI-Powered Travel Checklists" />
     <meta property="og:description" content="Generate intelligent, destination-specific packing lists with AI. Get weather-aware, culturally-informed recommendations tailored to your travel style." />

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Trip Wise - Smart Packing Assistant",
+  "short_name": "Trip Wise",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#1d4ed8",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "48x48 72x72 96x96 128x128",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/public/native/android/app/src/main/res/anim/splash_fade_in.xml
+++ b/public/native/android/app/src/main/res/anim/splash_fade_in.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="600"
+    android:fromAlpha="0.0"
+    android:toAlpha="1.0" />

--- a/public/native/android/app/src/main/res/anim/splash_fade_out.xml
+++ b/public/native/android/app/src/main/res/anim/splash_fade_out.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="500"
+    android:fromAlpha="1.0"
+    android:toAlpha="0.0" />

--- a/public/native/android/app/src/main/res/anim/splash_scale.xml
+++ b/public/native/android/app/src/main/res/anim/splash_scale.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<scale xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="800"
+    android:fromXScale="0.95"
+    android:toXScale="1.05"
+    android:fromYScale="0.95"
+    android:toYScale="1.05"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:repeatCount="1"
+    android:repeatMode="reverse" />

--- a/public/native/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/public/native/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#f97316"
+        android:fillAlpha="0.85"
+        android:pathData="M80,80h352c35.3,0 64,28.7 64,64v224c0,35.3 -28.7,64 -64,64H80c-35.3,0 -64,-28.7 -64,-64V144c0,-35.3 28.7,-64 64,-64z"/>
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M176,168c0,-30 26,-56 56,-56h48c30,0 56,26 56,56v32h24c22,0 40,18 40,40v120c0,26 -22,48 -48,48H160c-26,0 -48,-22 -48,-48V240c0,-22 18,-40 40,-40h24zm48,-32c-13,0 -24,11 -24,24v8h112v-8c0,-13 -11,-24 -24,-24z"/>
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M256,232a56,56 0 1,1 0,112 56,56 0 0,1 0,-112zm0,24a32,32 0 1,0 0,64 32,32 0 0,0 0,-64z"/>
+</vector>

--- a/public/native/android/app/src/main/res/drawable/splash_background.xml
+++ b/public/native/android/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <gradient
+                android:startColor="#1d4ed8"
+                android:endColor="#f97316"
+                android:angle="135" />
+        </shape>
+    </item>
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/trip_wise_logo" />
+    </item>
+</layer-list>

--- a/public/native/android/app/src/main/res/drawable/trip_wise_logo.xml
+++ b/public/native/android/app/src/main/res/drawable/trip_wise_logo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+    <path
+        android:fillColor="#1d4ed8"
+        android:pathData="M16,120c0,-57.6 46.4,-104 104,-104h272c57.6,0 104,46.4 104,104v272c0,57.6 -46.4,104 -104,104H120c-57.6,0 -104,-46.4 -104,-104z"/>
+    <path
+        android:fillColor="#f97316"
+        android:fillAlpha="0.6"
+        android:pathData="M80,80h352c35.3,0 64,28.7 64,64v224c0,35.3 -28.7,64 -64,64H80c-35.3,0 -64,-28.7 -64,-64V144c0,-35.3 28.7,-64 64,-64z"/>
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M176,168c0,-30 26,-56 56,-56h48c30,0 56,26 56,56v32h24c22,0 40,18 40,40v120c0,26 -22,48 -48,48H160c-26,0 -48,-22 -48,-48V240c0,-22 18,-40 40,-40h24zm48,-32c-13,0 -24,11 -24,24v8h112v-8c0,-13 -11,-24 -24,-24z"/>
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M256,232a56,56 0 1,1 0,112 56,56 0 0,1 0,-112zm0,24a32,32 0 1,0 0,64 32,32 0 0,0 0,-64z"/>
+</vector>

--- a/public/native/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/public/native/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/public/native/android/app/src/main/res/values-night/splash_theme.xml
+++ b/public/native/android/app/src/main/res/values-night/splash_theme.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.TripWise.Splash" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowBackground">@drawable/splash_background</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+    </style>
+</resources>

--- a/public/native/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/public/native/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#0f172a</color>
+</resources>

--- a/public/native/android/app/src/main/res/values/splash_theme.xml
+++ b/public/native/android/app/src/main/res/values/splash_theme.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.TripWise.Splash" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:windowBackground">@drawable/splash_background</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowTranslucentStatus">false</item>
+    </style>
+</resources>

--- a/public/native/ios/LaunchScreen.storyboard
+++ b/public/native/ios/LaunchScreen.storyboard
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LaunchScreenViewController">
+    <device id="retina6_7" orientation="portrait" appearance="light" />
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21504" />
+        <capability name="Safe area layout guides" minToolsVersion="9.0" />
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0" />
+    </dependencies>
+    <scenes>
+        <scene sceneID="LaunchScene">
+            <objects>
+                <viewController storyboardIdentifier="LaunchScreenViewController" id="LaunchScreenViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="LaunchRootView">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844" />
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BackgroundView">
+                                <rect key="frame" x="0.0" y="0.0" width="390" height="844" />
+                                <color key="backgroundColor" red="0.1176" green="0.1607" blue="0.2588" alpha="1" colorSpace="calibratedRGB" />
+                            </view>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="TripWiseLogo" translatesAutoresizingMaskIntoConstraints="NO" id="LogoImage">
+                                <rect key="frame" x="97" y="312" width="196" height="220" />
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="SafeArea" />
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" />
+                        <constraints>
+                            <constraint firstItem="BackgroundView" firstAttribute="top" secondItem="LaunchRootView" secondAttribute="top" id="bg-top" />
+                            <constraint firstItem="BackgroundView" firstAttribute="leading" secondItem="LaunchRootView" secondAttribute="leading" id="bg-leading" />
+                            <constraint firstAttribute="trailing" secondItem="BackgroundView" secondAttribute="trailing" id="bg-trailing" />
+                            <constraint firstAttribute="bottom" secondItem="BackgroundView" secondAttribute="bottom" id="bg-bottom" />
+                            <constraint firstItem="LogoImage" firstAttribute="centerX" secondItem="SafeArea" secondAttribute="centerX" id="logo-centerX" />
+                            <constraint firstItem="LogoImage" firstAttribute="centerY" secondItem="SafeArea" secondAttribute="centerY" id="logo-centerY" />
+                            <constraint firstItem="LogoImage" firstAttribute="width" secondItem="SafeArea" secondAttribute="width" multiplier="0.5" id="logo-width" />
+                            <constraint firstItem="LogoImage" firstAttribute="height" secondItem="LogoImage" secondAttribute="width" multiplier="1.12" id="logo-height" />
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LaunchFirstResponder" userLabel="First Responder" sceneMemberID="firstResponder" />
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="TripWiseLogo" width="512" height="512" />
+    </resources>
+</document>

--- a/public/native/ios/TripWiseLogo.svg
+++ b/public/native/ios/TripWiseLogo.svg
@@ -1,0 +1,14 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Trip Wise Logo</title>
+  <desc id="desc">Stylized backpack inside a rounded gradient square.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+  </defs>
+  <rect x="16" y="16" width="480" height="480" rx="104" fill="url(#bg)" />
+  <path d="M176 168c0-30 26-56 56-56h48c30 0 56 26 56 56v32h24c22 0 40 18 40 40v120c0 26-22 48-48 48H160c-26 0-48-22-48-48V240c0-22 18-40 40-40h24zm48-32c-13 0-24 11-24 24v8h112v-8c0-13-11-24-24-24z" fill="#fff" />
+  <circle cx="256" cy="288" r="56" fill="#1d4ed8" opacity="0.2" />
+  <path d="M256 232a56 56 0 1 1 0 112 56 56 0 0 1 0-112zm0 24a32 32 0 1 0 0 64 32 32 0 0 0 0-64z" fill="#fff" />
+</svg>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,57 @@
+const CACHE_NAME = "trip-wise-mobile-cache-v1";
+const OFFLINE_URLS = ["/", "/index.html", "/favicon.ico", "/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(OFFLINE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET" || request.url.startsWith("chrome-extension")) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(request)
+        .then((response) => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone));
+          return response;
+        })
+        .catch(() => caches.match("/index.html"));
+    })
+  );
+});
+
+self.addEventListener("push", (event) => {
+  const data = event.data?.json() ?? { title: "Trip Wise", body: "You have packing tasks waiting." };
+  event.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body,
+      icon: "/favicon.ico",
+      vibrate: [100, 50, 100],
+      tag: "trip-wise-reminder",
+    })
+  );
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,36 @@
+import { useState } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { SplashScreen } from "@/components/mobile/SplashScreen";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
-);
+const App = () => {
+  const [isSplashVisible, setIsSplashVisible] = useState(true);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        {isSplashVisible && (
+          <SplashScreen duration={2600} onFinish={() => setIsSplashVisible(false)} />
+        )}
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+};
 
 export default App;

--- a/src/components/PackingChecklist.tsx
+++ b/src/components/PackingChecklist.tsx
@@ -1,492 +1,685 @@
-import { useState, useEffect } from "react";
+import type { TouchEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  Suspense,
+  lazy,
+} from "react";
+import { toast } from "sonner";
+import {
+  Backpack,
+  Bell,
+  Calendar,
+  Copy,
+  Download,
+  Loader2,
+  MapPin,
+  Plus,
+  User,
+  WifiOff,
+} from "lucide-react";
+
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Progress } from "@/components/ui/progress";
-import { toast } from "sonner";
-import { 
-  MapPin, Calendar, User, Backpack, Loader2, Copy, Download, 
-  Bell, Plus, X, Trash2, Check 
-} from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+import { BottomTabBar } from "@/components/mobile/BottomTabBar";
+import { FloatingActionButton } from "@/components/mobile/FloatingActionButton";
+import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
 import { supabase } from "@/integrations/supabase/client";
 
-interface ChecklistItem {
-  id: string;
-  text: string;
-  checked: boolean;
-  category: string;
-}
+import { ChecklistItem, PackingListData } from "./checklist/types";
 
-interface ChecklistCategory {
-  name: string;
-  items: string[];
-}
+const ChecklistResults = lazy(() => import("@/components/checklist/ChecklistResults"));
 
-interface PackingListData {
-  weatherContext: string;
-  culturalTips: string;
-  categories: ChecklistCategory[];
+const tabs = [
+  { key: "plan", label: "Plan", icon: <MapPin className="h-5 w-5" /> },
+  { key: "pack", label: "Pack", icon: <Backpack className="h-5 w-5" /> },
+  { key: "reminders", label: "Remind", icon: <Bell className="h-5 w-5" /> },
+  { key: "settings", label: "Settings", icon: <User className="h-5 w-5" /> },
+];
+
+const travelStyles = [
+  { value: "backpacking", label: "Backpacking" },
+  { value: "business", label: "Business" },
+  { value: "luxury", label: "Luxury" },
+  { value: "adventure", label: "Adventure" },
+  { value: "family", label: "Family" },
+  { value: "solo", label: "Solo" },
+];
+
+function triggerHaptic(pattern: number | number[] = 16) {
+  if ("vibrate" in navigator) {
+    try {
+      navigator.vibrate(pattern);
+    } catch (error) {
+      console.error("Haptic feedback not supported", error);
+    }
+  }
 }
 
 export function PackingChecklist() {
+  const [activeTab, setActiveTab] = useState<string>("plan");
   const [destination, setDestination] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [ageGroup, setAgeGroup] = useState("");
   const [travelStyle, setTravelStyle] = useState("");
-  
   const [loading, setLoading] = useState(false);
   const [checklistData, setChecklistData] = useState<PackingListData | null>(null);
   const [checklistItems, setChecklistItems] = useState<ChecklistItem[]>([]);
   const [reminderSet, setReminderSet] = useState(false);
   const [reminderDays, setReminderDays] = useState<number | null>(null);
   const [customTask, setCustomTask] = useState("");
-
-  // Calculate progress
-  const progress = checklistItems.length > 0 
-    ? (checklistItems.filter(item => item.checked).length / checklistItems.length) * 100 
-    : 0;
+  const [showActions, setShowActions] = useState(false);
+  const [hapticsEnabled, setHapticsEnabled] = useState(true);
+  const [notificationPermission, setNotificationPermission] = useState<NotificationPermission | "unsupported">("default");
+  const [isOffline, setIsOffline] = useState(!navigator.onLine);
 
   useEffect(() => {
-    if (checklistData) {
-      // Convert categories to flat checklist items
-      const items: ChecklistItem[] = [];
-      checklistData.categories.forEach(category => {
-        category.items.forEach(item => {
-          items.push({
-            id: `${category.name}-${item}-${Math.random()}`,
-            text: item,
-            checked: false,
-            category: category.name
-          });
+    const handleOnlineStatus = () => setIsOffline(!navigator.onLine);
+    window.addEventListener("online", handleOnlineStatus);
+    window.addEventListener("offline", handleOnlineStatus);
+    handleOnlineStatus();
+    return () => {
+      window.removeEventListener("online", handleOnlineStatus);
+      window.removeEventListener("offline", handleOnlineStatus);
+    };
+  }, []);
+
+  useEffect(() => {
+    if ("Notification" in window) {
+      setNotificationPermission(Notification.permission);
+    } else {
+      setNotificationPermission("unsupported");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!checklistData) return;
+    const items: ChecklistItem[] = [];
+    checklistData.categories.forEach((category) => {
+      category.items.forEach((item) => {
+        const uniqueId =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : Math.random().toString(36).slice(2);
+
+        items.push({
+          id: `${category.name}-${item}-${uniqueId}`,
+          text: item,
+          checked: false,
+          category: category.name,
         });
       });
-      setChecklistItems(items);
-    }
+    });
+    setChecklistItems(items);
   }, [checklistData]);
 
-  const handleGenerate = async () => {
-    if (!destination || !startDate || !endDate || !ageGroup || !travelStyle) {
-      toast.error("Please fill in all fields");
-      return;
-    }
+  const progress = useMemo(() => {
+    if (checklistItems.length === 0) return 0;
+    const completed = checklistItems.filter((item) => item.checked).length;
+    return (completed / checklistItems.length) * 100;
+  }, [checklistItems]);
 
-    if (new Date(endDate) < new Date(startDate)) {
-      toast.error("End date must be after start date");
-      return;
-    }
+  const groupedItems = useMemo(() => {
+    return checklistItems.reduce((acc, item) => {
+      if (!acc[item.category]) acc[item.category] = [];
+      acc[item.category].push(item);
+      return acc;
+    }, {} as Record<string, ChecklistItem[]>);
+  }, [checklistItems]);
 
-    setLoading(true);
-    try {
-      const { data, error } = await supabase.functions.invoke('generate-packing-list', {
-        body: { destination, startDate, endDate, ageGroup, travelStyle }
-      });
+  const handleGenerate = useCallback(
+    async (isRefresh = false) => {
+      if (!destination || !startDate || !endDate || !ageGroup || !travelStyle) {
+        if (!isRefresh) {
+          toast.error("Please fill in all fields");
+        }
+        return;
+      }
 
-      if (error) throw error;
-      
-      setChecklistData(data);
-      toast.success("Packing list generated!");
-    } catch (error) {
-      console.error('Error generating packing list:', error);
-      toast.error("Failed to generate packing list. Please try again.");
-    } finally {
-      setLoading(false);
-    }
-  };
+      if (new Date(endDate) < new Date(startDate)) {
+        toast.error("End date must be after start date");
+        return;
+      }
 
-  const toggleItem = (id: string) => {
-    setChecklistItems(items => 
-      items.map(item => 
-        item.id === id ? { ...item, checked: !item.checked } : item
-      )
-    );
-  };
+      setLoading(true);
+      try {
+        const { data, error } = await supabase.functions.invoke("generate-packing-list", {
+          body: { destination, startDate, endDate, ageGroup, travelStyle },
+        });
 
-  const deleteItem = (id: string) => {
-    setChecklistItems(items => items.filter(item => item.id !== id));
+        if (error) throw error;
+
+        setChecklistData(data);
+        if (!isRefresh) {
+          toast.success("Packing list generated!");
+          triggerHaptic();
+          setActiveTab("pack");
+        } else {
+          toast.success("Packing insights refreshed");
+        }
+      } catch (error) {
+        console.error("Error generating packing list:", error);
+        toast.error("Failed to generate packing list. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [ageGroup, destination, endDate, startDate, travelStyle]
+  );
+
+  const pullToRefreshRef = usePullToRefresh<HTMLDivElement>({
+    onRefresh: () => {
+      triggerHaptic([10, 20, 10]);
+      if (checklistData) {
+        toast("Refreshing your packing insights...");
+        void handleGenerate(true);
+      }
+    },
+  });
+
+  const toggleItem = useCallback(
+    (id: string) => {
+      setChecklistItems((items) =>
+        items.map((item) =>
+          item.id === id ? { ...item, checked: !item.checked } : item
+        )
+      );
+      if (hapticsEnabled) triggerHaptic();
+    },
+    [hapticsEnabled]
+  );
+
+  const deleteItem = useCallback((id: string) => {
+    setChecklistItems((items) => items.filter((item) => item.id !== id));
     toast.success("Item deleted");
-  };
+  }, []);
 
-  const addCustomTask = () => {
+  const addCustomTask = useCallback(() => {
     if (!customTask.trim()) {
       toast.error("Please enter a task");
       return;
     }
-    
+
     const newItem: ChecklistItem = {
       id: `custom-${Date.now()}`,
       text: customTask,
       checked: false,
-      category: "Custom"
+      category: "Custom",
     };
-    
-    setChecklistItems([...checklistItems, newItem]);
+
+    setChecklistItems((items) => [...items, newItem]);
     setCustomTask("");
     toast.success("Custom task added");
-  };
+    if (hapticsEnabled) triggerHaptic([10, 16]);
+  }, [customTask, hapticsEnabled]);
 
-  const resetChecklist = () => {
-    setChecklistItems(items => items.map(item => ({ ...item, checked: false })));
+  const resetChecklist = useCallback(() => {
+    setChecklistItems((items) => items.map((item) => ({ ...item, checked: false })));
     toast.success("Checklist reset");
-  };
+  }, []);
 
-  const setReminder = (days: number) => {
-    if (!startDate) {
-      toast.error("Please set travel dates first");
-      return;
-    }
+  const setReminder = useCallback(
+    (days: number) => {
+      if (!startDate) {
+        toast.error("Please set travel dates first");
+        return false;
+      }
 
-    const reminderDate = new Date(startDate);
-    reminderDate.setDate(reminderDate.getDate() - days);
+      const reminderDate = new Date(startDate);
+      reminderDate.setDate(reminderDate.getDate() - days);
 
-    if (reminderDate < new Date()) {
-      toast.error("Cannot set reminder for a past date");
-      return;
-    }
+      if (reminderDate < new Date()) {
+        toast.error("Cannot set reminder for a past date");
+        return false;
+      }
 
-    setReminderSet(true);
-    setReminderDays(days);
-    toast.success(`Reminder set for ${days} day${days > 1 ? 's' : ''} before trip`);
-  };
+      setReminderSet(true);
+      setReminderDays(days);
+      toast.success(`Reminder set for ${days} day${days > 1 ? "s" : ""} before trip`);
+      if (hapticsEnabled) triggerHaptic([10, 10, 10]);
+      return true;
+    },
+    [hapticsEnabled, startDate]
+  );
 
-  const copyToClipboard = () => {
+  const copyToClipboard = useCallback(() => {
     if (!checklistData) return;
 
     let text = `PACKING LIST FOR ${destination.toUpperCase()}\n`;
     text += `${startDate} to ${endDate}\n\n`;
     text += `WEATHER: ${checklistData.weatherContext}\n\n`;
     text += `CULTURAL TIPS: ${checklistData.culturalTips}\n\n`;
-    
-    checklistItems.forEach(item => {
+
+    checklistItems.forEach((item) => {
       const checkbox = item.checked ? "☑" : "☐";
       text += `${checkbox} ${item.text}\n`;
     });
 
     navigator.clipboard.writeText(text);
     toast.success("Copied to clipboard!");
-  };
+    if (hapticsEnabled) triggerHaptic([16, 6, 16]);
+  }, [checklistData, checklistItems, destination, endDate, hapticsEnabled, startDate]);
 
-  const downloadChecklist = () => {
+  const downloadChecklist = useCallback(() => {
     if (!checklistData) return;
 
     let text = `PACKING LIST FOR ${destination.toUpperCase()}\n`;
     text += `${startDate} to ${endDate}\n\n`;
     text += `WEATHER: ${checklistData.weatherContext}\n\n`;
     text += `CULTURAL TIPS: ${checklistData.culturalTips}\n\n`;
-    
-    checklistItems.forEach(item => {
+
+    checklistItems.forEach((item) => {
       const checkbox = item.checked ? "☑" : "☐";
       text += `${checkbox} ${item.text}\n`;
     });
 
-    const blob = new Blob([text], { type: 'text/plain' });
+    const blob = new Blob([text], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `packing-list-${destination.toLowerCase().replace(/\s+/g, '-')}.txt`;
-    a.click();
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `packing-list-${destination.toLowerCase().replace(/\s+/g, "-")}.txt`;
+    anchor.click();
+    URL.revokeObjectURL(url);
     toast.success("Checklist downloaded!");
-  };
+  }, [checklistData, checklistItems, destination, endDate, startDate]);
 
-  // Group items by category for display
-  const groupedItems = checklistItems.reduce((acc, item) => {
-    if (!acc[item.category]) acc[item.category] = [];
-    acc[item.category].push(item);
-    return acc;
-  }, {} as Record<string, ChecklistItem[]>);
+  const requestNotifications = useCallback(async () => {
+    if (!("Notification" in window)) {
+      toast.error("Push notifications are not supported on this device");
+      setNotificationPermission("unsupported");
+      return;
+    }
+    const permission = await Notification.requestPermission();
+    setNotificationPermission(permission);
+    if (permission === "granted") {
+      toast.success("Notifications enabled");
+    } else {
+      toast("Notifications remain disabled");
+    }
+  }, []);
 
-  return (
-    <div className="min-h-screen gradient-hero py-8 px-4">
-      <div className="max-w-4xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="text-center text-white mb-8">
-          <h1 className="text-4xl sm:text-5xl font-bold mb-3 flex items-center justify-center gap-3">
-            <Backpack className="w-10 h-10" />
-            Smart Packing Assistant
-          </h1>
-          <p className="text-lg sm:text-xl opacity-90">
-            AI-powered, destination-specific packing lists tailored to you
-          </p>
-        </div>
+  const locateMe = useCallback(() => {
+    if (!navigator.geolocation) {
+      toast.error("Geolocation is not supported");
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        try {
+          const { latitude, longitude } = position.coords;
+          const response = await fetch(
+            `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}`,
+            {
+              headers: { "User-Agent": "TripWise Mobile/1.0" },
+            }
+          );
+          const data = await response.json();
+          const locationLabel = data.address?.city || data.address?.town || data.address?.state || "";
+          if (locationLabel) {
+            setDestination(locationLabel);
+            toast.success(`Destination set to ${locationLabel}`);
+          } else {
+            toast("Location detected");
+          }
+        } catch (error) {
+          console.error("Reverse geocoding failed", error);
+          toast.error("Unable to resolve location");
+        }
+      },
+      () => toast.error("Unable to fetch location"),
+      { enableHighAccuracy: true, timeout: 7000 }
+    );
+  }, []);
 
-        {/* Input Form */}
-        <Card className="gradient-card shadow-xl">
-          <CardHeader>
-            <CardTitle className="text-2xl">Trip Details</CardTitle>
-            <CardDescription>
-              Tell us about your journey for personalized recommendations
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="destination" className="flex items-center gap-2">
-                <MapPin className="w-4 h-4" />
-                Destination
-              </Label>
+  const handleSwipeTabs = useCallback(() => {
+    let startX = 0;
+    let endX = 0;
+
+    return {
+      onTouchStart: (event: TouchEvent<HTMLDivElement>) => {
+        startX = event.touches[0].clientX;
+      },
+      onTouchEnd: () => {
+        const delta = endX - startX;
+        const currentIndex = tabs.findIndex((tab) => tab.key === activeTab);
+        if (Math.abs(delta) > 60) {
+          const nextIndex = delta < 0 ? currentIndex + 1 : currentIndex - 1;
+          const nextTab = tabs[nextIndex];
+          if (nextTab) {
+            setActiveTab(nextTab.key);
+          }
+        }
+      },
+      onTouchMove: (event: TouchEvent<HTMLDivElement>) => {
+        endX = event.touches[0].clientX;
+      },
+    };
+  }, [activeTab]);
+
+  const swipeHandlers = handleSwipeTabs();
+
+  const planContent = (
+    <div className="space-y-5">
+      <Card className="rounded-3xl border-none bg-gradient-to-br from-background via-background to-primary/5 shadow-lg shadow-primary/10">
+        <CardHeader className="pb-4">
+          <CardTitle className="text-2xl font-semibold">Trip Details</CardTitle>
+          <CardDescription>Personalize your mobile-ready packing assistant</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="destination" className="flex items-center gap-2 text-sm font-semibold">
+              <MapPin className="h-4 w-4" /> Destination
+            </Label>
+            <div className="flex gap-2">
               <Input
                 id="destination"
-                placeholder="e.g., Tokyo, Paris, New York"
+                placeholder="Tokyo, Paris, New York"
                 value={destination}
-                onChange={(e) => setDestination(e.target.value)}
-                className="touch-target"
+                onChange={(event) => setDestination(event.target.value)}
+                className="flex-1 touch-target rounded-2xl"
+                inputMode="text"
+                autoComplete="on"
+              />
+              <Button variant="secondary" size="icon" className="rounded-2xl" onClick={locateMe}>
+                <MapPin className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="startDate" className="flex items-center gap-2 text-sm font-semibold">
+                <Calendar className="h-4 w-4" /> Start Date
+              </Label>
+              <Input
+                id="startDate"
+                type="date"
+                value={startDate}
+                onChange={(event) => setStartDate(event.target.value)}
+                className="touch-target rounded-2xl"
               />
             </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="startDate" className="flex items-center gap-2">
-                  <Calendar className="w-4 h-4" />
-                  Start Date
-                </Label>
-                <Input
-                  id="startDate"
-                  type="date"
-                  value={startDate}
-                  onChange={(e) => setStartDate(e.target.value)}
-                  className="touch-target"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="endDate" className="flex items-center gap-2">
-                  <Calendar className="w-4 h-4" />
-                  End Date
-                </Label>
-                <Input
-                  id="endDate"
-                  type="date"
-                  value={endDate}
-                  onChange={(e) => setEndDate(e.target.value)}
-                  className="touch-target"
-                />
-              </div>
-            </div>
-
             <div className="space-y-2">
-              <Label htmlFor="ageGroup" className="flex items-center gap-2">
-                <User className="w-4 h-4" />
-                Age Group
+              <Label htmlFor="endDate" className="flex items-center gap-2 text-sm font-semibold">
+                <Calendar className="h-4 w-4" /> End Date
               </Label>
-              <Select value={ageGroup} onValueChange={setAgeGroup}>
-                <SelectTrigger id="ageGroup" className="touch-target">
-                  <SelectValue placeholder="Select age group" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="child">Child (0-12)</SelectItem>
-                  <SelectItem value="teen">Teen (13-17)</SelectItem>
-                  <SelectItem value="adult">Adult (18-64)</SelectItem>
-                  <SelectItem value="senior">Senior (65+)</SelectItem>
-                </SelectContent>
-              </Select>
+              <Input
+                id="endDate"
+                type="date"
+                value={endDate}
+                onChange={(event) => setEndDate(event.target.value)}
+                className="touch-target rounded-2xl"
+              />
             </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="travelStyle" className="flex items-center gap-2">
-                <Backpack className="w-4 h-4" />
-                Travel Style
-              </Label>
-              <Select value={travelStyle} onValueChange={setTravelStyle}>
-                <SelectTrigger id="travelStyle" className="touch-target">
-                  <SelectValue placeholder="Select travel style" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="backpacking">Backpacking</SelectItem>
-                  <SelectItem value="business">Business</SelectItem>
-                  <SelectItem value="luxury">Luxury</SelectItem>
-                  <SelectItem value="adventure">Adventure</SelectItem>
-                  <SelectItem value="family">Family</SelectItem>
-                  <SelectItem value="solo">Solo</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <Button 
-              onClick={handleGenerate} 
-              disabled={loading}
-              className="w-full touch-target text-base font-semibold"
-              size="lg"
-            >
-              {loading ? (
-                <>
-                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                  Generating Your List...
-                </>
-              ) : (
-                <>
-                  <Backpack className="w-5 h-5 mr-2" />
-                  Generate Smart Checklist
-                </>
-              )}
-            </Button>
-          </CardContent>
-        </Card>
-
-        {/* Results */}
-        {checklistData && (
-          <div className="space-y-4">
-            {/* Context Cards */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Card className="bg-primary/10 border-primary/20">
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base sm:text-lg">Weather Context</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm sm:text-base">{checklistData.weatherContext}</p>
-                </CardContent>
-              </Card>
-
-              <Card className="bg-secondary/10 border-secondary/20">
-                <CardHeader className="pb-3">
-                  <CardTitle className="text-base sm:text-lg">Cultural Tips</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm sm:text-base">{checklistData.culturalTips}</p>
-                </CardContent>
-              </Card>
-            </div>
-
-            {/* Progress Bar */}
-            <Card>
-              <CardContent className="pt-6">
-                <div className="space-y-2">
-                  <div className="flex justify-between text-sm">
-                    <span className="font-medium">Packing Progress</span>
-                    <span className="text-muted-foreground">
-                      {checklistItems.filter(i => i.checked).length} / {checklistItems.length} items
-                    </span>
-                  </div>
-                  <Progress value={progress} className="h-3" />
-                  <p className="text-center text-xs text-muted-foreground">
-                    {Math.round(progress)}% Complete
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Action Buttons */}
-            <div className="flex flex-wrap gap-2">
-              <Button 
-                onClick={copyToClipboard} 
-                variant="outline" 
-                size="sm"
-                className="touch-target"
-              >
-                <Copy className="w-4 h-4 mr-2" />
-                Copy
-              </Button>
-              
-              <Button 
-                onClick={downloadChecklist} 
-                variant="outline" 
-                size="sm"
-                className="touch-target"
-              >
-                <Download className="w-4 h-4 mr-2" />
-                Download
-              </Button>
-              
-              <Button 
-                onClick={resetChecklist} 
-                variant="outline" 
-                size="sm"
-                className="touch-target"
-              >
-                <X className="w-4 h-4 mr-2" />
-                Reset
-              </Button>
-
-              <Select onValueChange={(value) => setReminder(parseInt(value))}>
-                <SelectTrigger 
-                  className={`w-auto touch-target ${reminderSet ? 'bg-accent/10 border-accent' : ''}`}
-                >
-                  <Bell className={`w-4 h-4 mr-2 ${reminderSet ? 'text-accent' : ''}`} />
-                  <SelectValue placeholder="Set Reminder" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="1">1 day before</SelectItem>
-                  <SelectItem value="3">3 days before</SelectItem>
-                  <SelectItem value="7">1 week before</SelectItem>
-                  <SelectItem value="14">2 weeks before</SelectItem>
-                </SelectContent>
-              </Select>
-
-              {reminderSet && reminderDays && (
-                <span className="text-sm text-accent flex items-center gap-1">
-                  <Check className="w-4 h-4" />
-                  Reminder set ({reminderDays}d)
-                </span>
-              )}
-            </div>
-
-            {/* Add Custom Task */}
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex gap-2">
-                  <Input
-                    placeholder="Add custom task..."
-                    value={customTask}
-                    onChange={(e) => setCustomTask(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && addCustomTask()}
-                    className="touch-target"
-                  />
-                  <Button onClick={addCustomTask} size="sm" className="touch-target">
-                    <Plus className="w-4 h-4" />
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Checklist by Category */}
-            {Object.entries(groupedItems).map(([category, items]) => (
-              <Card key={category}>
-                <CardHeader>
-                  <CardTitle className="text-lg sm:text-xl">{category}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    {items.map((item) => (
-                      <div 
-                        key={item.id}
-                        className="flex items-center gap-3 p-2 sm:p-3 rounded-lg hover:bg-muted/50 transition-colors group"
-                      >
-                        <button
-                          onClick={() => toggleItem(item.id)}
-                          className="flex items-center gap-3 flex-1 text-left touch-target"
-                        >
-                          <div className={`w-5 h-5 sm:w-6 sm:h-6 border-2 rounded flex items-center justify-center transition-all ${
-                            item.checked 
-                              ? 'bg-accent border-accent' 
-                              : 'border-border hover:border-accent/50'
-                          }`}>
-                            {item.checked && (
-                              <Check className="w-3 h-3 sm:w-4 sm:h-4 text-white animate-check" />
-                            )}
-                          </div>
-                          <span className={`text-sm sm:text-base ${
-                            item.checked ? 'line-through text-muted-foreground' : ''
-                          }`}>
-                            {item.text}
-                          </span>
-                        </button>
-                        <Button
-                          onClick={() => deleteItem(item.id)}
-                          variant="ghost"
-                          size="sm"
-                          className="opacity-0 group-hover:opacity-100 transition-opacity"
-                        >
-                          <Trash2 className="w-4 h-4 text-destructive" />
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
           </div>
-        )}
-      </div>
+
+          <div className="space-y-2">
+            <Label className="flex items-center gap-2 text-sm font-semibold">
+              <User className="h-4 w-4" /> Age Group
+            </Label>
+            <Select value={ageGroup} onValueChange={setAgeGroup}>
+              <SelectTrigger className="touch-target rounded-2xl">
+                <SelectValue placeholder="Select age group" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="child">Child (0-12)</SelectItem>
+                <SelectItem value="teen">Teen (13-17)</SelectItem>
+                <SelectItem value="adult">Adult (18-64)</SelectItem>
+                <SelectItem value="senior">Senior (65+)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-3">
+            <Label className="flex items-center gap-2 text-sm font-semibold">
+              <Download className="h-4 w-4" /> Travel Style
+            </Label>
+            <ToggleGroup
+              type="single"
+              className="grid grid-cols-2 gap-2 rounded-2xl bg-muted/60 p-2"
+              value={travelStyle}
+              onValueChange={(value) => value && setTravelStyle(value)}
+            >
+              {travelStyles.map((style) => (
+                <ToggleGroupItem
+                  key={style.value}
+                  value={style.value}
+                  className="touch-target rounded-xl text-xs font-semibold"
+                >
+                  {style.label}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </div>
+
+          <Button
+            onClick={() => void handleGenerate(false)}
+            disabled={loading}
+            className="w-full touch-target rounded-2xl text-base font-semibold shadow-lg shadow-primary/25"
+            size="lg"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Generating Your List...
+              </>
+            ) : (
+              <>
+                <Download className="mr-2 h-5 w-5" /> Generate Smart Checklist
+              </>
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-3xl border-none bg-muted/40 p-4">
+        <CardTitle className="text-base font-semibold">Packing Progress</CardTitle>
+        <CardContent className="mt-4 space-y-3 p-0">
+          <Progress value={progress} className="h-3 rounded-full" />
+          <p className="text-sm text-muted-foreground">
+            {checklistItems.filter((item) => item.checked).length} of {checklistItems.length} items packed
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+
+  const remindersContent = (
+    <div className="space-y-4">
+      <Card className="rounded-3xl border-none bg-muted/40 p-6">
+        <CardTitle className="text-lg font-semibold">Reminder Center</CardTitle>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Sync reminders across devices with push notifications and offline support.
+        </p>
+        <div className="mt-6 space-y-4">
+          <Button variant="outline" className="w-full rounded-2xl" onClick={() => setShowActions(true)}>
+            Schedule packing reminder
+          </Button>
+          <div className="rounded-2xl bg-background p-4 shadow-sm">
+            <p className="text-sm font-semibold">Reminder Status</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {reminderSet && reminderDays
+                ? `Reminder scheduled ${reminderDays} day(s) before your trip.`
+                : "No reminder scheduled yet."}
+            </p>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+
+  const settingsContent = (
+    <div className="space-y-4">
+      <Card className="rounded-3xl border-none bg-muted/40 p-6">
+        <CardTitle className="text-lg font-semibold">Mobile Preferences</CardTitle>
+        <div className="mt-4 space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold">Haptic feedback</p>
+              <p className="text-xs text-muted-foreground">Vibrate on key actions for tactile response.</p>
+            </div>
+            <Switch checked={hapticsEnabled} onCheckedChange={setHapticsEnabled} />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-semibold">Push notifications</p>
+              <p className="text-xs text-muted-foreground">
+                {notificationPermission === "granted"
+                  ? "Enabled"
+                  : notificationPermission === "denied"
+                  ? "Denied"
+                  : notificationPermission === "unsupported"
+                  ? "Unsupported"
+                  : "Tap to enable"}
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={requestNotifications}
+              className="rounded-full"
+              disabled={notificationPermission === "unsupported"}
+            >
+              Enable
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+
+  const packContent = checklistData ? (
+    <Suspense
+      fallback={
+        <div className="flex h-64 items-center justify-center">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      }
+    >
+      <ChecklistResults
+        checklistData={checklistData}
+        checklistItems={checklistItems}
+        groupedItems={groupedItems}
+        progress={progress}
+        reminderSet={reminderSet}
+        reminderDays={reminderDays}
+        customTask={customTask}
+        onToggleItem={toggleItem}
+        onDeleteItem={deleteItem}
+        onResetChecklist={resetChecklist}
+        onSetReminder={setReminder}
+        onCustomTaskChange={setCustomTask}
+        onCustomTaskSubmit={addCustomTask}
+        onDownload={downloadChecklist}
+        onCopy={copyToClipboard}
+      />
+    </Suspense>
+  ) : (
+    <Card className="rounded-3xl border-none bg-muted/40 p-8 text-center">
+      <CardTitle className="text-lg font-semibold">Generate a packing list to get started</CardTitle>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Complete your trip details and tap Generate to see personalized recommendations.
+      </p>
+    </Card>
+  );
+
+  return (
+    <div className="mobile-shell">
+      <header className="mobile-safe-area sticky top-0 z-40 bg-background/95 px-4 py-4 backdrop-blur-md">
+        <div className="mx-auto flex w-full max-w-xl items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">Trip Wise</h1>
+            <p className="text-xs text-muted-foreground">Smart Packing Assistant</p>
+          </div>
+          {isOffline && (
+            <span className="flex items-center gap-2 rounded-full bg-destructive/10 px-3 py-1 text-xs font-semibold text-destructive">
+              <WifiOff className="h-3.5 w-3.5" /> Offline
+            </span>
+          )}
+        </div>
+      </header>
+
+      <main
+        ref={pullToRefreshRef}
+        className="mobile-content px-4"
+        {...swipeHandlers}
+      >
+        <div className="mx-auto w-full max-w-xl space-y-6 py-6">
+          {activeTab === "plan" && planContent}
+          {activeTab === "pack" && packContent}
+          {activeTab === "reminders" && remindersContent}
+          {activeTab === "settings" && settingsContent}
+        </div>
+      </main>
+
+      <FloatingActionButton
+        icon={<Plus className="h-5 w-5" />}
+        label="Quick actions"
+        onClick={() => setShowActions(true)}
+      />
+
+      <BottomTabBar activeTab={activeTab} onChange={setActiveTab} items={tabs} />
+
+      <Sheet open={showActions} onOpenChange={setShowActions}>
+        <SheetContent side="bottom" className="mobile-safe-area rounded-t-3xl">
+          <SheetHeader>
+            <SheetTitle>Quick Actions</SheetTitle>
+          </SheetHeader>
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <Button
+              className="rounded-2xl"
+              variant="secondary"
+              onClick={() => {
+                setActiveTab("plan");
+                setShowActions(false);
+              }}
+            >
+              Update trip details
+            </Button>
+            <Button
+              className="rounded-2xl"
+              onClick={() => {
+                copyToClipboard();
+                setShowActions(false);
+              }}
+            >
+              <Copy className="mr-2 h-4 w-4" /> Copy list
+            </Button>
+            <Button
+              className="rounded-2xl"
+              onClick={() => {
+                downloadChecklist();
+                setShowActions(false);
+              }}
+            >
+              <Download className="mr-2 h-4 w-4" /> Download
+            </Button>
+            <Button
+              className="rounded-2xl"
+              variant="outline"
+              onClick={() => {
+                const scheduled = setReminder(1);
+                if (scheduled) {
+                  setActiveTab("reminders");
+                  setShowActions(false);
+                }
+              }}
+            >
+              <Bell className="mr-2 h-4 w-4" /> Reminder tomorrow
+            </Button>
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/src/components/checklist/ChecklistResults.tsx
+++ b/src/components/checklist/ChecklistResults.tsx
@@ -1,0 +1,182 @@
+import { memo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Check, Download, Trash2, X } from "lucide-react";
+import { ChecklistItem, PackingListData } from "./types";
+
+interface ChecklistResultsProps {
+  checklistData: PackingListData;
+  checklistItems: ChecklistItem[];
+  groupedItems: Record<string, ChecklistItem[]>;
+  progress: number;
+  reminderSet: boolean;
+  reminderDays: number | null;
+  customTask: string;
+  onToggleItem: (id: string) => void;
+  onDeleteItem: (id: string) => void;
+  onResetChecklist: () => void;
+  onSetReminder: (days: number) => boolean | void;
+  onCustomTaskChange: (value: string) => void;
+  onCustomTaskSubmit: () => void;
+  onDownload: () => void;
+  onCopy: () => void;
+}
+
+const ChecklistResultsComponent = memo(function ChecklistResults({
+  checklistData,
+  checklistItems,
+  groupedItems,
+  progress,
+  reminderSet,
+  reminderDays,
+  customTask,
+  onToggleItem,
+  onDeleteItem,
+  onResetChecklist,
+  onSetReminder,
+  onCustomTaskChange,
+  onCustomTaskSubmit,
+  onDownload,
+  onCopy,
+}: ChecklistResultsProps) {
+  return (
+    <div className="space-y-4 pb-28">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Card className="bg-primary/10 border-primary/20">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Weather Context</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm leading-relaxed text-foreground/80">
+              {checklistData.weatherContext}
+            </p>
+          </CardContent>
+        </Card>
+        <Card className="bg-secondary/10 border-secondary/20">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Cultural Tips</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm leading-relaxed text-foreground/80">
+              {checklistData.culturalTips}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <div className="space-y-3 rounded-2xl bg-muted/60 p-4">
+            <div className="flex items-center justify-between text-sm font-medium">
+              <span>Packing Progress</span>
+              <span className="text-muted-foreground">
+                {checklistItems.filter((i) => i.checked).length} / {checklistItems.length} items
+              </span>
+            </div>
+            <Progress value={progress} className="h-3 rounded-full" />
+            <p className="text-center text-xs uppercase tracking-wide text-muted-foreground">
+              {Math.round(progress)}% Complete
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <Button onClick={onCopy} variant="outline" className="touch-target text-xs font-semibold">
+              Copy
+            </Button>
+            <Button onClick={onDownload} variant="outline" className="touch-target text-xs font-semibold">
+              <Download className="mr-2 h-4 w-4" />Download
+            </Button>
+            <Button onClick={onResetChecklist} variant="outline" className="touch-target text-xs font-semibold">
+              <X className="mr-2 h-4 w-4" />Reset
+            </Button>
+            <Select onValueChange={(value) => onSetReminder(Number(value))}>
+              <SelectTrigger
+                className={`touch-target text-xs font-semibold ${reminderSet ? "bg-accent/10 border-accent" : ""}`}
+              >
+                <SelectValue placeholder="Set Reminder" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">1 day before</SelectItem>
+                <SelectItem value="3">3 days before</SelectItem>
+                <SelectItem value="7">1 week before</SelectItem>
+                <SelectItem value="14">2 weeks before</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {reminderSet && reminderDays && (
+            <p className="flex items-center gap-2 text-sm text-accent">
+              <Check className="h-4 w-4" /> Reminder set ({reminderDays}d)
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3 pt-6">
+          <div className="flex items-center gap-2 rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-3">
+            <Input
+              placeholder="Add custom task..."
+              value={customTask}
+              onChange={(event) => onCustomTaskChange(event.target.value)}
+              onKeyDown={(event) => event.key === "Enter" && onCustomTaskSubmit()}
+              className="touch-target text-sm"
+            />
+            <Button onClick={onCustomTaskSubmit} size="sm" className="touch-target">
+              Add
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {Object.entries(groupedItems).map(([category, items]) => (
+        <Card key={category} className="overflow-hidden">
+          <CardHeader className="bg-muted/60 py-4">
+            <CardTitle className="text-base font-semibold">{category}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 py-3">
+            {items.map((item) => (
+              <div
+                key={item.id}
+                className="group flex items-center justify-between rounded-2xl px-2 py-2 hover:bg-muted"
+              >
+                <button
+                  onClick={() => onToggleItem(item.id)}
+                  className="flex flex-1 items-center gap-3 text-left touch-target"
+                >
+                  <div
+                    className={`flex h-6 w-6 items-center justify-center rounded-full border-2 transition-all ${
+                      item.checked ? "bg-accent border-accent" : "border-border"
+                    }`}
+                  >
+                    {item.checked && <Check className="h-3.5 w-3.5 text-white" />}
+                  </div>
+                  <span
+                    className={`text-sm font-medium transition-colors ${
+                      item.checked ? "text-muted-foreground line-through" : "text-foreground"
+                    }`}
+                  >
+                    {item.text}
+                  </span>
+                </button>
+                <Button
+                  onClick={() => onDeleteItem(item.id)}
+                  variant="ghost"
+                  size="sm"
+                  className="opacity-0 transition-opacity group-hover:opacity-100"
+                >
+                  <Trash2 className="h-4 w-4 text-destructive" />
+                </Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+});
+
+export default ChecklistResultsComponent;

--- a/src/components/checklist/types.ts
+++ b/src/components/checklist/types.ts
@@ -1,0 +1,17 @@
+export interface ChecklistItem {
+  id: string;
+  text: string;
+  checked: boolean;
+  category: string;
+}
+
+export interface ChecklistCategory {
+  name: string;
+  items: string[];
+}
+
+export interface PackingListData {
+  weatherContext: string;
+  culturalTips: string;
+  categories: ChecklistCategory[];
+}

--- a/src/components/mobile/BottomTabBar.tsx
+++ b/src/components/mobile/BottomTabBar.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+
+interface TabItem {
+  key: string;
+  label: string;
+  icon: ReactNode;
+}
+
+interface BottomTabBarProps {
+  activeTab: string;
+  onChange: (key: string) => void;
+  items: TabItem[];
+}
+
+export function BottomTabBar({ activeTab, onChange, items }: BottomTabBarProps) {
+  return (
+    <nav className="mobile-bottom-tab-bar border-t border-border/60 px-4 py-2">
+      <div className="mx-auto grid max-w-xl grid-cols-4 gap-2">
+        {items.map((item) => {
+          const isActive = activeTab === item.key;
+          return (
+            <button
+              key={item.key}
+              onClick={() => onChange(item.key)}
+              className={cn(
+                "flex flex-col items-center justify-center gap-1 rounded-2xl py-2 text-xs font-medium transition-all",
+                "touch-target",
+                isActive
+                  ? "bg-primary/10 text-primary shadow-sm"
+                  : "text-muted-foreground hover:bg-muted/70"
+              )}
+              aria-pressed={isActive}
+            >
+              <span className={cn("transition-transform", isActive ? "scale-110" : "scale-100")}>{item.icon}</span>
+              <span>{item.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/mobile/FloatingActionButton.tsx
+++ b/src/components/mobile/FloatingActionButton.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface FloatingActionButtonProps {
+  icon: ReactNode;
+  label?: string;
+  onClick: () => void;
+}
+
+export function FloatingActionButton({ icon, label, onClick }: FloatingActionButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "fixed bottom-24 right-6 z-50 inline-flex items-center gap-2 rounded-full bg-primary px-5 py-4",
+        "text-primary-foreground font-semibold shadow-lg fab-shadow transition-transform duration-200",
+        "touch-target hover:scale-105 active:scale-95"
+      )}
+      aria-label={label ?? "Primary action"}
+    >
+      {icon}
+      {label && <span className="text-sm">{label}</span>}
+    </button>
+  );
+}

--- a/src/components/mobile/SplashScreen.tsx
+++ b/src/components/mobile/SplashScreen.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { Backpack } from "lucide-react";
+
+interface SplashScreenProps {
+  duration?: number;
+  onFinish: () => void;
+}
+
+export function SplashScreen({ duration = 2400, onFinish }: SplashScreenProps) {
+  const [isLeaving, setIsLeaving] = useState(false);
+
+  useEffect(() => {
+    const enterTimer = window.setTimeout(() => {
+      setIsLeaving(true);
+    }, Math.max(1000, duration - 450));
+
+    const exitTimer = window.setTimeout(() => {
+      onFinish();
+    }, duration);
+
+    return () => {
+      window.clearTimeout(enterTimer);
+      window.clearTimeout(exitTimer);
+    };
+  }, [duration, onFinish]);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex flex-col items-center justify-center bg-gradient-to-br from-primary via-secondary to-accent text-white transition-opacity duration-500 ${
+        isLeaving ? "fade-out" : "fade-in"
+      } mobile-safe-area`}
+    >
+      <div className="flex flex-col items-center gap-6">
+        <div className="flex h-24 w-24 items-center justify-center rounded-3xl bg-white/10 backdrop-blur-sm">
+          <Backpack className="h-14 w-14 animate-pulse" />
+        </div>
+        <div className="text-center">
+          <p className="text-sm uppercase tracking-[0.4em] text-white/70">Trip Wise</p>
+          <h1 className="text-3xl font-semibold tracking-tight">Smart Packing Assistant</h1>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-pull-to-refresh.ts
+++ b/src/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,68 @@
+import { useCallback, useRef } from "react";
+
+type PullToRefreshOptions = {
+  threshold?: number;
+  onRefresh: () => void;
+};
+
+export function usePullToRefresh<T extends HTMLElement>({
+  onRefresh,
+  threshold = 68,
+}: PullToRefreshOptions) {
+  const startYRef = useRef<number | null>(null);
+  const isPullingRef = useRef(false);
+  const containerRef = useRef<T | null>(null);
+
+  const onTouchStart = useCallback(
+    (event: TouchEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      if (container.scrollTop === 0) {
+        startYRef.current = event.touches[0].clientY;
+        isPullingRef.current = true;
+      }
+    },
+    []
+  );
+
+  const onTouchMove = useCallback(
+    (event: TouchEvent) => {
+      if (!isPullingRef.current || startYRef.current === null) return;
+      const currentY = event.touches[0].clientY;
+      const distance = currentY - startYRef.current;
+
+      if (distance > threshold) {
+        isPullingRef.current = false;
+        startYRef.current = null;
+        onRefresh();
+      }
+    },
+    [onRefresh, threshold]
+  );
+
+  const reset = useCallback(() => {
+    isPullingRef.current = false;
+    startYRef.current = null;
+  }, []);
+
+  const setRef = useCallback(
+    (node: T | null) => {
+      if (containerRef.current) {
+        containerRef.current.removeEventListener("touchstart", onTouchStart);
+        containerRef.current.removeEventListener("touchmove", onTouchMove);
+        containerRef.current.removeEventListener("touchend", reset);
+      }
+
+      containerRef.current = node;
+
+      if (node) {
+        node.addEventListener("touchstart", onTouchStart, { passive: true });
+        node.addEventListener("touchmove", onTouchMove, { passive: true });
+        node.addEventListener("touchend", reset, { passive: true });
+      }
+    },
+    [onTouchMove, onTouchStart, reset]
+  );
+
+  return setRef;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,8 @@ All colors MUST be HSL.
   }
 
   body {
+    font-family: "SF Pro Text", "SF Pro Display", "Roboto", "Helvetica Neue", system-ui,
+      -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     @apply bg-background text-foreground antialiased;
   }
 }
@@ -126,5 +128,67 @@ All colors MUST be HSL.
   .touch-target {
     min-height: 44px;
     min-width: 44px;
+  }
+
+  .mobile-safe-area {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .mobile-shell {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--background);
+  }
+
+  .mobile-content {
+    flex: 1;
+    position: relative;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .mobile-bottom-tab-bar {
+    position: sticky;
+    bottom: 0;
+    z-index: 40;
+    background: color-mix(in srgb, hsl(var(--background)) 90%, transparent);
+    backdrop-filter: blur(16px);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .fab-shadow {
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.16);
+  }
+
+  .fade-in {
+    animation: fadeIn 320ms ease-out forwards;
+  }
+
+  .fade-out {
+    animation: fadeOut 260ms ease-in forwards;
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(12px);
+    }
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,16 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+const container = document.getElementById("root");
+
+if (container) {
+  createRoot(container).render(<App />);
+}
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/service-worker.js")
+      .catch((error) => console.error("Service worker registration failed", error));
+  });
+}


### PR DESCRIPTION
## Summary
- wrap the packing checklist in a mobile-first shell with bottom navigation, floating quick actions, haptics, and refreshed input flow
- split checklist rendering into a lazily loaded results view and add reusable mobile utilities including pull-to-refresh and splash screen handling
- wire up PWA essentials, offline caching, and provide native iOS/Android splash resources plus manifest updates for app-like launches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df765bd9e08326b66bcab49d6e8296